### PR TITLE
fix WriteUnifiedDiff/WriteContextDiff fmt.Sprintf error

### DIFF
--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -559,8 +559,12 @@ type UnifiedDiff struct {
 func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 	buf := bufio.NewWriter(writer)
 	defer buf.Flush()
-	w := func(format string, args ...interface{}) error {
+	wf := func(format string, args ...interface{}) error {
 		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		return err
+	}
+	ws := func(s string) error {
+		_, err := buf.WriteString(s)
 		return err
 	}
 
@@ -581,11 +585,11 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 			if len(diff.ToDate) > 0 {
 				toDate = "\t" + diff.ToDate
 			}
-			err := w("--- %s%s%s", diff.FromFile, fromDate, diff.Eol)
+			err := wf("--- %s%s%s", diff.FromFile, fromDate, diff.Eol)
 			if err != nil {
 				return err
 			}
-			err = w("+++ %s%s%s", diff.ToFile, toDate, diff.Eol)
+			err = wf("+++ %s%s%s", diff.ToFile, toDate, diff.Eol)
 			if err != nil {
 				return err
 			}
@@ -593,14 +597,14 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 		first, last := g[0], g[len(g)-1]
 		range1 := formatRangeUnified(first.I1, last.I2)
 		range2 := formatRangeUnified(first.J1, last.J2)
-		if err := w("@@ -%s +%s @@%s", range1, range2, diff.Eol); err != nil {
+		if err := wf("@@ -%s +%s @@%s", range1, range2, diff.Eol); err != nil {
 			return err
 		}
 		for _, c := range g {
 			i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
 			if c.Tag == 'e' {
 				for _, line := range diff.A[i1:i2] {
-					if err := w(" " + line); err != nil {
+					if err := ws(" " + line); err != nil {
 						return err
 					}
 				}
@@ -608,14 +612,14 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 			}
 			if c.Tag == 'r' || c.Tag == 'd' {
 				for _, line := range diff.A[i1:i2] {
-					if err := w("-" + line); err != nil {
+					if err := ws("-" + line); err != nil {
 						return err
 					}
 				}
 			}
 			if c.Tag == 'r' || c.Tag == 'i' {
 				for _, line := range diff.B[j1:j2] {
-					if err := w("+" + line); err != nil {
+					if err := ws("+" + line); err != nil {
 						return err
 					}
 				}

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -102,11 +102,13 @@ group
 	}
 }
 
-func ExampleGetUnifiedDiffString() {
+func ExampleGetUnifiedDiffCode() {
 	a := `one
 two
 three
-four`
+four
+fmt.Printf("%s,%T",a,b)
+`
 	b := `zero
 one
 three
@@ -121,16 +123,88 @@ four`
 		Context:  3,
 	}
 	result, _ := GetUnifiedDiffString(diff)
-	fmt.Printf(strings.Replace(result, "\t", " ", -1))
+	fmt.Println(strings.Replace(result, "\t", " ", -1))
 	// Output:
 	// --- Original 2005-01-26 23:30:50
 	// +++ Current 2010-04-02 10:20:52
-	// @@ -1,4 +1,4 @@
+	// @@ -1,6 +1,4 @@
 	// +zero
 	//  one
 	// -two
 	//  three
 	//  four
+	// -fmt.Printf("%s,%T",a,b)
+	// -
+}
+
+func ExampleGetUnifiedDiffString() {
+	a := `one
+two
+three
+four
+fmt.Printf("%s,%T",a,b)
+`
+	b := `zero
+one
+three
+four`
+	diff := UnifiedDiff{
+		A:        SplitLines(a),
+		B:        SplitLines(b),
+		FromFile: "Original",
+		FromDate: "2005-01-26 23:30:50",
+		ToFile:   "Current",
+		ToDate:   "2010-04-02 10:20:52",
+		Context:  3,
+	}
+	result, _ := GetUnifiedDiffString(diff)
+	fmt.Println(strings.Replace(result, "\t", " ", -1))
+	// Output:
+	// --- Original 2005-01-26 23:30:50
+	// +++ Current 2010-04-02 10:20:52
+	// @@ -1,6 +1,4 @@
+	// +zero
+	//  one
+	// -two
+	//  three
+	//  four
+	// -fmt.Printf("%s,%T",a,b)
+	// -
+}
+
+func ExampleGetContextDiffCode() {
+	a := `one
+two
+three
+four`
+	b := `zero
+one
+tree
+four`
+	diff := ContextDiff{
+		A:        SplitLines(a),
+		B:        SplitLines(b),
+		FromFile: "Original",
+		ToFile:   "Current",
+		Context:  3,
+		Eol:      "\n",
+	}
+	result, _ := GetContextDiffString(diff)
+	fmt.Printf(strings.Replace(result, "\t", " ", -1))
+	// Output:
+	// *** Original
+	// --- Current
+	// ***************
+	// *** 1,4 ****
+	//   one
+	// ! two
+	// ! three
+	//   four
+	// --- 1,4 ----
+	// + zero
+	//   one
+	// ! tree
+	//   four
 }
 
 func ExampleGetContextDiffString() {

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -107,8 +107,7 @@ func ExampleGetUnifiedDiffCode() {
 two
 three
 four
-fmt.Printf("%s,%T",a,b)
-`
+fmt.Printf("%s,%T",a,b)`
 	b := `zero
 one
 three
@@ -127,56 +126,21 @@ four`
 	// Output:
 	// --- Original 2005-01-26 23:30:50
 	// +++ Current 2010-04-02 10:20:52
-	// @@ -1,6 +1,4 @@
+	// @@ -1,5 +1,4 @@
 	// +zero
 	//  one
 	// -two
 	//  three
 	//  four
 	// -fmt.Printf("%s,%T",a,b)
-	// -
-}
-
-func ExampleGetUnifiedDiffString() {
-	a := `one
-two
-three
-four
-fmt.Printf("%s,%T",a,b)
-`
-	b := `zero
-one
-three
-four`
-	diff := UnifiedDiff{
-		A:        SplitLines(a),
-		B:        SplitLines(b),
-		FromFile: "Original",
-		FromDate: "2005-01-26 23:30:50",
-		ToFile:   "Current",
-		ToDate:   "2010-04-02 10:20:52",
-		Context:  3,
-	}
-	result, _ := GetUnifiedDiffString(diff)
-	fmt.Println(strings.Replace(result, "\t", " ", -1))
-	// Output:
-	// --- Original 2005-01-26 23:30:50
-	// +++ Current 2010-04-02 10:20:52
-	// @@ -1,6 +1,4 @@
-	// +zero
-	//  one
-	// -two
-	//  three
-	//  four
-	// -fmt.Printf("%s,%T",a,b)
-	// -
 }
 
 func ExampleGetContextDiffCode() {
 	a := `one
 two
 three
-four`
+four
+fmt.Printf("%s,%T",a,b)`
 	b := `zero
 one
 tree
@@ -190,16 +154,17 @@ four`
 		Eol:      "\n",
 	}
 	result, _ := GetContextDiffString(diff)
-	fmt.Printf(strings.Replace(result, "\t", " ", -1))
+	fmt.Print(strings.Replace(result, "\t", " ", -1))
 	// Output:
 	// *** Original
 	// --- Current
 	// ***************
-	// *** 1,4 ****
+	// *** 1,5 ****
 	//   one
 	// ! two
 	// ! three
 	//   four
+	// - fmt.Printf("%s,%T",a,b)
 	// --- 1,4 ----
 	// + zero
 	//   one


### PR DESCRIPTION
The WriteUnifiedDiff and WriteContextDiff func use fmt.Sprint to output, if diff string has %s ... flag to error output.

fmt.Printf("%s,%T",a,b) => fmt.Printf("%!s(MISSING),%!T(MISSING)\n", obj, obj)
