### PR TITLE
Rework line ending handling

### DIFF
--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -606,7 +606,7 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 			i1, i2, j1, j2 := c.I1, c.I2, c.J1, c.J2
 			if c.Tag == 'e' {
 				for _, line := range diff.A[i1:i2] {
-					if err := ws(" " + line); err != nil {
+					if err := ws(" " + line + diff.Eol); err != nil {
 						return err
 					}
 				}
@@ -614,14 +614,14 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 			}
 			if c.Tag == 'r' || c.Tag == 'd' {
 				for _, line := range diff.A[i1:i2] {
-					if err := ws("-" + line); err != nil {
+					if err := ws("-" + line + diff.Eol); err != nil {
 						return err
 					}
 				}
 			}
 			if c.Tag == 'r' || c.Tag == 'i' {
 				for _, line := range diff.B[j1:j2] {
-					if err := ws("+" + line); err != nil {
+					if err := ws("+" + line + diff.Eol); err != nil {
 						return err
 					}
 				}
@@ -730,7 +730,7 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 						continue
 					}
 					for _, line := range diff.A[cc.I1:cc.I2] {
-						ws(prefix[cc.Tag] + line)
+						ws(prefix[cc.Tag] + line + diff.Eol)
 					}
 				}
 				break
@@ -746,7 +746,7 @@ func WriteContextDiff(writer io.Writer, diff ContextDiff) error {
 						continue
 					}
 					for _, line := range diff.B[cc.J1:cc.J2] {
-						ws(prefix[cc.Tag] + line)
+						ws(prefix[cc.Tag] + line + diff.Eol)
 					}
 				}
 				break
@@ -763,10 +763,9 @@ func GetContextDiffString(diff ContextDiff) (string, error) {
 	return string(w.Bytes()), err
 }
 
-// Split a string on "\n" while preserving them. The output can be used
+// Split a string on "\n". The output can be used
 // as input for UnifiedDiff and ContextDiff structures.
 func SplitLines(s string) []string {
-	lines := strings.SplitAfter(s, "\n")
-	lines[len(lines)-1] += "\n"
+	lines := strings.Split(strings.TrimSpace(s), "\n")
 	return lines
 }

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -161,12 +161,12 @@ func (m *SequenceMatcher) chainB() {
 	m.bJunk = map[string]struct{}{}
 	if m.IsJunk != nil {
 		junk := m.bJunk
-		for s, _ := range b2j {
+		for s := range b2j {
 			if m.IsJunk(s) {
 				junk[s] = struct{}{}
 			}
 		}
-		for s, _ := range junk {
+		for s := range junk {
 			delete(b2j, s)
 		}
 	}
@@ -181,7 +181,7 @@ func (m *SequenceMatcher) chainB() {
 				popular[s] = struct{}{}
 			}
 		}
-		for s, _ := range popular {
+		for s := range popular {
 			delete(b2j, s)
 		}
 	}
@@ -268,7 +268,7 @@ func (m *SequenceMatcher) findLongestMatch(alo, ahi, blo, bhi int) Match {
 	for besti+bestsize < ahi && bestj+bestsize < bhi &&
 		!m.isBJunk(m.b[bestj+bestsize]) &&
 		m.a[besti+bestsize] == m.b[bestj+bestsize] {
-		bestsize += 1
+		bestsize++
 	}
 
 	// Now that we have a wholly interesting match (albeit possibly
@@ -285,7 +285,7 @@ func (m *SequenceMatcher) findLongestMatch(alo, ahi, blo, bhi int) Match {
 	for besti+bestsize < ahi && bestj+bestsize < bhi &&
 		m.isBJunk(m.b[bestj+bestsize]) &&
 		m.a[besti+bestsize] == m.b[bestj+bestsize] {
-		bestsize += 1
+		bestsize++
 	}
 
 	return Match{A: besti, B: bestj, Size: bestsize}
@@ -496,7 +496,7 @@ func (m *SequenceMatcher) QuickRatio() float64 {
 		}
 		avail[s] = n - 1
 		if n > 0 {
-			matches += 1
+			matches++
 		}
 	}
 	return calculateRatio(matches, len(m.a)+len(m.b))
@@ -520,7 +520,7 @@ func formatRangeUnified(start, stop int) string {
 		return fmt.Sprintf("%d", beginning)
 	}
 	if length == 0 {
-		beginning -= 1 // empty ranges begin at line just before the range
+		beginning-- // empty ranges begin at line just before the range
 	}
 	return fmt.Sprintf("%d,%d", beginning, length)
 }
@@ -644,7 +644,7 @@ func formatRangeContext(start, stop int) string {
 	beginning := start + 1 // lines start numbering with one
 	length := stop - start
 	if length == 0 {
-		beginning -= 1 // empty ranges begin at line just before the range
+		beginning-- // empty ranges begin at line just before the range
 	}
 	if length <= 1 {
 		return fmt.Sprintf("%d", beginning)

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -105,7 +105,7 @@ group
 	}
 }
 
-func ExampleGetUnifiedDiffCode() {
+func ExampleGetUnifiedDiffString() {
 	a := `one
 two
 three
@@ -138,7 +138,7 @@ four`
 	// -fmt.Printf("%s,%T",a,b)
 }
 
-func ExampleGetContextDiffCode() {
+func ExampleGetContextDiffString() {
 	a := `one
 two
 three
@@ -168,41 +168,6 @@ four`
 	// ! three
 	//   four
 	// - fmt.Printf("%s,%T",a,b)
-	// --- 1,4 ----
-	// + zero
-	//   one
-	// ! tree
-	//   four
-}
-
-func ExampleGetContextDiffString() {
-	a := `one
-two
-three
-four`
-	b := `zero
-one
-tree
-four`
-	diff := ContextDiff{
-		A:        SplitLines(a),
-		B:        SplitLines(b),
-		FromFile: "Original",
-		ToFile:   "Current",
-		Context:  3,
-		Eol:      "\n",
-	}
-	result, _ := GetContextDiffString(diff)
-	fmt.Printf(strings.Replace(result, "\t", " ", -1))
-	// Output:
-	// *** Original
-	// --- Current
-	// ***************
-	// *** 1,4 ****
-	//   one
-	// ! two
-	// ! three
-	//   four
 	// --- 1,4 ----
 	// + zero
 	//   one

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -15,9 +15,12 @@ func assertAlmostEqual(t *testing.T, a, b float64, places int) {
 	}
 }
 
-func assertEqual(t *testing.T, a, b interface{}) {
-	if !reflect.DeepEqual(a, b) {
-		t.Errorf("%v != %v", a, b)
+func assertEqual(t *testing.T, got, want interface{}) {
+	if !reflect.DeepEqual(got, want) {
+		fmt.Println("got:")
+		fmt.Printf("%#v\n", got)
+		fmt.Println("want:")
+		fmt.Printf("%#v\n", want)
 	}
 }
 
@@ -329,14 +332,14 @@ func TestOutputFormatTabDelimiter(t *testing.T) {
 	ud, err := GetUnifiedDiffString(diff)
 	assertEqual(t, err, nil)
 	assertEqual(t, SplitLines(ud)[:2], []string{
-		"--- Original\t2005-01-26 23:30:50\n",
-		"+++ Current\t2010-04-12 10:20:52\n",
+		"--- Original\t2005-01-26 23:30:50",
+		"+++ Current\t2010-04-12 10:20:52",
 	})
 	cd, err := GetContextDiffString(ContextDiff(diff))
 	assertEqual(t, err, nil)
 	assertEqual(t, SplitLines(cd)[:2], []string{
-		"*** Original\t2005-01-26 23:30:50\n",
-		"--- Current\t2010-04-12 10:20:52\n",
+		"*** Original\t2005-01-26 23:30:50",
+		"--- Current\t2010-04-12 10:20:52",
 	})
 }
 
@@ -350,11 +353,11 @@ func TestOutputFormatNoTrailingTabOnEmptyFiledate(t *testing.T) {
 	}
 	ud, err := GetUnifiedDiffString(diff)
 	assertEqual(t, err, nil)
-	assertEqual(t, SplitLines(ud)[:2], []string{"--- Original\n", "+++ Current\n"})
+	assertEqual(t, SplitLines(ud)[:2], []string{"--- Original", "+++ Current"})
 
 	cd, err := GetContextDiffString(ContextDiff(diff))
 	assertEqual(t, err, nil)
-	assertEqual(t, SplitLines(cd)[:2], []string{"*** Original\n", "--- Current\n"})
+	assertEqual(t, SplitLines(cd)[:2], []string{"*** Original", "--- Current"})
 }
 
 func TestOmitFilenames(t *testing.T) {
@@ -366,29 +369,27 @@ func TestOmitFilenames(t *testing.T) {
 	ud, err := GetUnifiedDiffString(diff)
 	assertEqual(t, err, nil)
 	assertEqual(t, SplitLines(ud), []string{
-		"@@ -0,0 +1,2 @@\n",
-		"+t\n",
-		"+w\n",
-		"@@ -2,2 +3,0 @@\n",
-		"-n\n",
-		"-e\n",
-		"\n",
+		"@@ -0,0 +1,2 @@",
+		"+t",
+		"+w",
+		"@@ -2,2 +3,0 @@",
+		"-n",
+		"-e",
 	})
 
 	cd, err := GetContextDiffString(ContextDiff(diff))
 	assertEqual(t, err, nil)
 	assertEqual(t, SplitLines(cd), []string{
-		"***************\n",
-		"*** 0 ****\n",
-		"--- 1,2 ----\n",
-		"+ t\n",
-		"+ w\n",
-		"***************\n",
-		"*** 2,3 ****\n",
-		"- n\n",
-		"- e\n",
-		"--- 3 ----\n",
-		"\n",
+		"***************",
+		"*** 0 ****",
+		"--- 1,2 ----",
+		"+ t",
+		"+ w",
+		"***************",
+		"*** 2,3 ****",
+		"- n",
+		"- e",
+		"--- 3 ----",
 	})
 }
 
@@ -397,9 +398,9 @@ func TestSplitLines(t *testing.T) {
 		input string
 		want  []string
 	}{
-		{"foo", []string{"foo\n"}},
-		{"foo\nbar", []string{"foo\n", "bar\n"}},
-		{"foo\nbar\n", []string{"foo\n", "bar\n", "\n"}},
+		{"foo", []string{"foo"}},
+		{"foo\nbar", []string{"foo", "bar"}},
+		{"foo\nbar\n", []string{"foo", "bar"}},
 	}
 	for _, test := range allTests {
 		assertEqual(t, SplitLines(test.input), test.want)


### PR DESCRIPTION
Hello & thank for a nice lib!
I needed to repurpose it a little hence the pull request.
These changes will break current usage, because it changes how lines are stored
It was changed to render line endings with diff.Eol so it could display properly on Windows,
and now simply returns a []string with the diff, without line endings encoded.

The second commit is just some tweaks that gometalinter mentioned.
