### PR TITLE
Implement a []byte-base API in a "bytes" subpackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ would output:
 Differ has been implemented primarily for the Compare() function at this time.
 
 ```Go
+diff := difflib.NewDiffer()
 out, err := diff.Compare(
     []string{"foo\n", "bar\n", "baz\n"},
 	[]string{"foo\n", "bar1\n", "asdf\n", "baz\n"})

--- a/README.md
+++ b/README.md
@@ -1,29 +1,30 @@
 go-difflib
 ==========
 
-THIS PACKAGE IS NO LONGER MAINTAINED.
+The previous owner of this project (pmezard) did not have the time to continue
+working on it. Additionally I (ianbruene) needed additional ported features.
 
-At this point, I have no longer the time nor the interest to work on go-difflib. I apologize for the inconvenience.
+I have taken over maintenance and further development of the project
 
-[![GoDoc](https://godoc.org/github.com/pmezard/go-difflib/difflib?status.svg)](https://godoc.org/github.com/pmezard/go-difflib/difflib)
+[![GoDoc](https://godoc.org/github.com/ianbruene/go-difflib/difflib?status.svg)](https://godoc.org/github.com/ianbruene/go-difflib/difflib)
 
 Go-difflib is a partial port of python 3 difflib package. Its main goal
-was to make unified and context diff available in pure Go, mostly for
-testing purposes.
+is to make unified and context diff available in pure Go.
 
 The following class and functions (and related tests) have be ported:
 
 * `SequenceMatcher`
+* `Differ`
 * `unified_diff()`
 * `context_diff()`
 
 ## Installation
 
 ```bash
-$ go get github.com/pmezard/go-difflib/difflib
+$ go get github.com/ianbruene/go-difflib/difflib
 ```
 
-### Quick Start
+### UnifiedDiff Quick Start
 
 Diffs are configured with Unified (or ContextDiff) structures, and can
 be output to an io.Writer or returned as a string.
@@ -51,3 +52,23 @@ would output:
 +baz
 ```
 
+### Differ Quick Start
+
+Differ has been implemented primarily for the Compare() function at this time.
+
+```Go
+out, err := diff.Compare(
+    []string{"foo\n", "bar\n", "baz\n"},
+	[]string{"foo\n", "bar1\n", "asdf\n", "baz\n"})
+```
+
+would output:
+
+```
+  foo
+- bar
++ bar1
+?    +
++ asdf
+  baz
+```

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ go-difflib
 The previous owner of this project (pmezard) did not have the time to continue
 working on it. Additionally I (ianbruene) needed additional ported features.
 
-I have taken over maintenance and further development of the project
+For these reasons I have taken over maintenance and further development of the
+project.
 
 [![GoDoc](https://godoc.org/github.com/ianbruene/go-difflib/difflib?status.svg)](https://godoc.org/github.com/ianbruene/go-difflib/difflib)
 
-Go-difflib is a partial port of python 3 difflib package. Its main goal
-is to make unified and context diff available in pure Go.
+Go-difflib is an as yet partial port of python 3's difflib package.
 
-The following class and functions (and related tests) have be ported:
+The following publicly visible classes and functions have been ported:
 
 * `SequenceMatcher`
 * `Differ`

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -531,6 +531,18 @@ func count_leading(line string, ch byte) (count int) {
 	return count
 }
 
+type DiffLine struct {
+	Tag char
+	Line string
+}
+
+func NewDiffLine(tag char, line string) (l *DiffLine) {
+	l = &DiffLine{}
+	l.Tag = tag
+	l.Line = line
+	return l
+}
+
 type Differ struct {
 	Linejunk func(string) bool
 	Charjunk func(string) bool

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -599,6 +599,7 @@ func (d *Differ) Dump(tag string, x []string, low int, high int) (out []string) 
 	sout := d.StructuredDump(tag[0], x, low, high)
 	out = make([]string, len(sout))
 	var bld strings.Builder
+	bld.Grow(1024)
 	for i, line := range sout {
 		bld.Reset()
 		bld.WriteByte(line.Tag)

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -816,14 +816,16 @@ type UnifiedDiff struct {
 // 'fromfile', 'tofile', 'fromfiledate', and 'tofiledate'.
 // The modification times are normally expressed in the ISO 8601 format.
 func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
-	buf := bufio.NewWriter(writer)
-	defer buf.Flush()
+	//buf := bufio.NewWriter(writer)
+	//defer buf.Flush()
+	var bld strings.Builder
+	bld.Reset()
 	wf := func(format string, args ...interface{}) error {
-		_, err := buf.WriteString(fmt.Sprintf(format, args...))
+		_, err := fmt.Fprintf(&bld, format, args...)
 		return err
 	}
 	ws := func(s string) error {
-		_, err := buf.WriteString(s)
+		_, err := bld.WriteString(s)
 		return err
 	}
 
@@ -887,6 +889,9 @@ func WriteUnifiedDiff(writer io.Writer, diff UnifiedDiff) error {
 			}
 		}
 	}
+	buf := bufio.NewWriter(writer)
+	buf.WriteString(bld.String())
+	buf.Flush()
 	return nil
 }
 

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -598,8 +598,13 @@ func (d *Differ) Dump(tag string, x []string, low int, high int) (out []string) 
 	// Generate comparison results for a same-tagged range.
 	sout := d.StructuredDump(tag[0], x, low, high)
 	out = make([]string, len(sout))
+	var bld strings.Builder
 	for i, line := range sout {
-		out[i] = fmt.Sprintf("%s %s", string(line.Tag), line.Line)
+		bld.Reset()
+		bld.WriteByte(line.Tag)
+		bld.WriteString(" ")
+		bld.WriteString(line.Line)
+		out[i] = bld.String()
 	}
 	return out
 }

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -532,12 +532,12 @@ func count_leading(line string, ch byte) (count int) {
 }
 
 type DiffLine struct {
-	Tag char
+	Tag  byte
 	Line string
 }
 
-func NewDiffLine(tag char, line string) (l *DiffLine) {
-	l = &DiffLine{}
+func NewDiffLine(tag byte, line string) (l DiffLine) {
+	l = DiffLine{}
 	l.Tag = tag
 	l.Line = line
 	return l
@@ -583,6 +583,15 @@ func (d *Differ) Compare(a []string, b []string) (diffs []string, err error) {
 		diffs = append(diffs, g...)
 	}
 	return diffs, nil
+}
+
+func (d *Differ) StructuredDump(tag byte, x []string, low int, high int) (out []DiffLine) {
+	size := high - low
+	out = make([]DiffLine, size)
+	for i := 0; i < size; i++ {
+		out[i] = NewDiffLine(tag, x[i + low])
+	}
+	return out
 }
 
 func (d *Differ) Dump(tag string, x []string, lo int, hi int) (out []string) {

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -99,11 +99,12 @@ func newB2J (b []string) *B2J {
 				// The content already has a slot in its hash bucket. Just
 				// append the newly seen index to the slice in that slot
 				b2j.store[h][slotIndex] = append(slot, lineno)
-				continue
+				goto cont
 			}
 		}
 		// The line content still has no slot. Create one with a single value.
 		b2j.store[h] = append(b2j.store[h], []int{lineno})
+		cont:
 	}
 	return &b2j
 }

--- a/difflib/difflib.go
+++ b/difflib/difflib.go
@@ -594,11 +594,12 @@ func (d *Differ) StructuredDump(tag byte, x []string, low int, high int) (out []
 	return out
 }
 
-func (d *Differ) Dump(tag string, x []string, lo int, hi int) (out []string) {
+func (d *Differ) Dump(tag string, x []string, low int, high int) (out []string) {
 	// Generate comparison results for a same-tagged range.
-	out = []string{}
-	for i := lo; i < hi; i++ {
-		out = append(out, fmt.Sprintf("%s %s", tag, x[i]))
+	sout := d.StructuredDump(tag[0], x, low, high)
+	out = make([]string, len(sout))
+	for i, line := range sout {
+		out[i] = fmt.Sprintf("%s %s", string(line.Tag), line.Line)
 	}
 	return out
 }

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -453,6 +453,17 @@ func TestDifferCompare(t *testing.T) {
 	}
 }
 
+func TestDifferStructuredDump(t *testing.T) {
+	diff := NewDiffer()
+	out := diff.StructuredDump('+',
+		[]string{"foo", "bar", "baz", "quux", "qwerty"},
+		1, 3)
+	expected := []DiffLine{DiffLine{'+', "bar"}, DiffLine{'+', "baz"}}
+	if !reflect.DeepEqual(out, expected) {
+		t.Fatal("Differ StructuredDump failure:", out)
+	}
+}
+
 func TestDifferDump(t *testing.T) {
 	diff := NewDiffer()
 	out := diff.Dump("+",

--- a/difflib/difflib_test.go
+++ b/difflib/difflib_test.go
@@ -558,3 +558,22 @@ func TestDifferQFormat(t *testing.T) {
 		t.Fatal("Differ QFormat() failure:", out)
 	}
 }
+
+func TestGetUnifiedDiffString(t *testing.T) {
+	A := "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n"
+	B := "one\ntwo\nthr33\nfour\nfive\nsix\nseven\neight\nnine\nten\n"
+	// Build diff
+	diff := UnifiedDiff{A: SplitLines(A),
+		FromFile: "file", FromDate: "then",
+		B: SplitLines(B),
+		ToFile: "tile", ToDate: "now", Eol: "", Context: 1}
+	// Run test
+	diffStr, err := GetUnifiedDiffString(diff)
+	if err != nil {
+		t.Fatal("GetUnifiedDiffString error:", err)
+	}
+	exp := "--- file\tthen\n+++ tile\tnow\n@@ -2,3 +2,3 @@\n two\n-three\n+thr33\n four\n"
+	if diffStr != exp {
+		t.Fatal("GetUnifiedDiffString failure:", diffStr)
+	}
+}


### PR DESCRIPTION
Even with a lot of improvements compared to the current master, it still uses around 1.5x the time of the string-based implementation and API, so put it in a bytes subpackage and restore the original v1.1.2 string implementation in the toplevel package.
When/if the []byte API improves enough (or an interface{}-based one), this decision might be revisited to make the string API a user of the bytes subpackage.